### PR TITLE
fix: TW-28830 - show recategorization banner when changes are pending

### DIFF
--- a/attribution/custom_categories.html
+++ b/attribution/custom_categories.html
@@ -9,9 +9,8 @@
     h1 { font-size: 22px; font-weight: 600; margin-bottom: 4px; }
     .subtitle { color: #666; font-size: 14px; margin-bottom: 24px; }
 
-    /* BUG: banner is display:none even when recategorization is needed */
     .recategorize-banner {
-      display: none; /* ← BUG: should be display:flex when isDirty=true */
+      display: none; /* Hidden by default, shown via JavaScript when isDirty=true */
       align-items: center;
       gap: 12px;
       background: #fff8e1;
@@ -127,11 +126,10 @@
       alert('Recategorization started. This may take a few minutes.');
     }
 
-    // BUG: isDirty is correctly computed as true, but banner is never shown
-    // because the CSS has display:none hardcoded instead of being toggled here
+    // Show recategorization banner when there are pending changes
     const isDirty = document.querySelectorAll('.dirty-pill').length > 0;
-    console.log('isDirty:', isDirty); // logs true — but banner stays hidden
-    // Missing: document.getElementById('recategorizeBanner').style.display = isDirty ? 'flex' : 'none';
+    console.log('isDirty:', isDirty);
+    document.getElementById('recategorizeBanner').style.display = isDirty ? 'flex' : 'none';
   </script>
 </body>
 </html>

--- a/attribution/test_banner.html
+++ b/attribution/test_banner.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Test: Recategorization Banner</title>
+  <style>
+    body { font-family: system-ui, sans-serif; padding: 20px; background: #f0f0f0; }
+    .test-case { background: white; margin: 20px 0; padding: 20px; border-radius: 8px; }
+    .test-result { padding: 10px; margin: 10px 0; border-radius: 4px; }
+    .pass { background: #dcfce7; color: #166534; }
+    .fail { background: #fecaca; color: #dc2626; }
+    iframe { border: 1px solid #ddd; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Test: Custom Categories Banner Display</h1>
+  
+  <div class="test-case">
+    <h3>Test Case: Banner should show when dirty pills are present</h3>
+    <p>Expected: Banner visible (the custom_categories.html page has 3 "Changes pending" pills)</p>
+    
+    <iframe src="custom_categories.html" width="800" height="400"></iframe>
+    
+    <div id="testResult" class="test-result">
+      <strong>Test Status:</strong> <span id="status">Running...</span>
+    </div>
+  </div>
+
+  <script>
+    // Simple test to verify the banner logic
+    setTimeout(() => {
+      const iframe = document.querySelector('iframe');
+      const iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
+      
+      // Check if the banner is visible in the iframe
+      const banner = iframeDocument.getElementById('recategorizeBanner');
+      const isDirty = iframeDocument.querySelectorAll('.dirty-pill').length > 0;
+      const bannerVisible = window.getComputedStyle(banner).display === 'flex';
+      
+      const statusSpan = document.getElementById('status');
+      const resultDiv = document.getElementById('testResult');
+      
+      if (isDirty && bannerVisible) {
+        statusSpan.textContent = 'PASS - Banner is correctly shown when changes are pending';
+        resultDiv.className = 'test-result pass';
+      } else if (!isDirty && !bannerVisible) {
+        statusSpan.textContent = 'PASS - Banner is correctly hidden when no changes are pending';
+        resultDiv.className = 'test-result pass';
+      } else {
+        statusSpan.textContent = `FAIL - Expected banner visible: ${isDirty}, actual: ${bannerVisible}`;
+        resultDiv.className = 'test-result fail';
+      }
+    }, 1000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #3

### Summary
- Fixed recategorization banner not showing when campaign changes are pending
- Added missing JavaScript to toggle banner visibility based on `isDirty` state
- Banner now properly displays when there are pending category changes

### Test Plan
- Open `attribution/custom_categories.html` — banner should now be visible
- Open `attribution/test_banner.html` to run automated test
- Verify banner shows warning icon and "Recategorize Now" button

🤖 Generated with [Claude Code](https://claude.ai/code)